### PR TITLE
Zvol

### DIFF
--- a/houston-common-lib/lib/managers/zfs/manager.ts
+++ b/houston-common-lib/lib/managers/zfs/manager.ts
@@ -10,6 +10,7 @@ import {
   CommandOptions,
   ZPoolAddVDevOptions,
   DatasetCreateOptions,
+  ZvolCreateOptions,
   Disks,
   VDevDisk,
   ZPoolDestroyOptions,
@@ -25,6 +26,7 @@ export interface IZFSManager {
   destroyPool(name: string): Promise<void>;
   addVDevsToPool(pool: ZPoolBase, vdevs: VDev[], options: ZPoolAddVDevOptions): Promise<ExitedProcess>;
   addDataset(parent: string, name: string, options: DatasetCreateOptions): Promise<ExitedProcess>;
+  addZvol(parent: string, name: string, options: ZvolCreateOptions): Promise<ExitedProcess>;
   getBaseDisks(): Promise<VDevDisk[]>;
   getFullDisks(): Promise<VDevDisk[]>;
   getDiskCapacity(path: string): Promise<string>;
@@ -462,6 +464,31 @@ export class ZFSManager implements IZFSManager {
     }
   }
 
+
+  async addZvol(parent: string, name: string, options: ZvolCreateOptions): Promise<ExitedProcess> {
+    const argv = ["zfs", "create"];
+    const zvolProps: string[] = [];
+
+    if (options.volblocksize !== undefined) zvolProps.push(`volblocksize=${options.volblocksize}`);
+    if (options.compression !== undefined) zvolProps.push(`compression=${options.compression}`);
+    if (options.dedup !== undefined) zvolProps.push(`dedup=${options.dedup}`);
+    if (options.readonly !== undefined) zvolProps.push(`readonly=${options.readonly}`);
+
+    argv.push(...zvolProps.flatMap((prop) => ["-o", prop]));
+    argv.push("-V", options.volsize);
+    argv.push(`${parent}/${name}`);
+
+    console.log("****\ncmdstring:\n", ...argv, "\n****");
+
+    try {
+      const proc = await unwrap(this.server.execute(new Command(argv, this.commandOptions)));
+      console.log("Command output:", proc.getStdout());
+      return proc;
+    } catch (error) {
+      console.error("Error executing command:", error);
+      throw error;
+    }
+  }
 
   allDisksHaveSameCapacity(disks: VDevDisk[]): boolean {
     if (disks.length === 0) return false;

--- a/houston-common-lib/lib/managers/zfs/types.ts
+++ b/houston-common-lib/lib/managers/zfs/types.ts
@@ -226,6 +226,7 @@ export interface ZFSFileSystemInfo {
     };
     used?: number;
     usedBySnapshots?: string;
+    volsize?: number;
   };
   parentFS?: string;
   children?: ZFSFileSystemInfo[];

--- a/houston-common-lib/lib/managers/zfs/types.ts
+++ b/houston-common-lib/lib/managers/zfs/types.ts
@@ -167,6 +167,14 @@ export interface DatasetCreateOptions {
   readonly?: string;
 }
 
+export interface ZvolCreateOptions {
+  volsize: string;
+  volblocksize?: string;
+  compression?: string;
+  dedup?: string;
+  readonly?: string;
+}
+
 export interface Dataset extends DatasetBase {
   parent: string;
   children?: Dataset[];


### PR DESCRIPTION
Add Zvol Support to ZFS Manager
Summary
Adds zvol (ZFS volume) creation capability to ZFSManager and the supporting types.

Changes
New ZvolCreateOptions interface in types.ts — defines options for zvol creation: volsize (required), volblocksize, compression, dedup, readonly
New addZvol() method on ZFSManager and IZFSManager in manager.ts — builds and executes zfs create -V <size> [-o prop=val ...] <parent>/<name>
Added volsize property to ZFSFileSystemInfo.properties for tracking zvol size in the UI
