### PR TITLE
Fixes useSpawn executing cockpit.spawn twice and clears spawnhandle reference in cockpitDriver

### DIFF
--- a/cockpit-typings/cockpit.d.ts
+++ b/cockpit-typings/cockpit.d.ts
@@ -180,6 +180,8 @@ declare module 'cockpit' {
         proxy(interface: string, path: string, options?: { watch?: boolean }): DBusProxy;
         call(path: string, iface: string, method: string, args?: any[]): Promise<any>;
         subscribe(match: { interface?: string; member?: string; path?: string }, callback: (path: string, iface: string, signal: string, args: any[]) => void): { remove(): void };
+        addEventListener(event: string, handler: (...args: any[]) => void): void;
+        removeEventListener(event: string, handler: (...args: any[]) => void): void;
         close(): void;
     }
 

--- a/cockpit-typings/cockpit.d.ts
+++ b/cockpit-typings/cockpit.d.ts
@@ -178,6 +178,8 @@ declare module 'cockpit' {
         readonly unique_name: string;
         readonly options: DBusOptions;
         proxy(interface: string, path: string, options?: { watch?: boolean }): DBusProxy;
+        call(path: string, iface: string, method: string, args?: any[]): Promise<any>;
+        subscribe(match: { interface?: string; member?: string; path?: string }, callback: (path: string, iface: string, signal: string, args: any[]) => void): { remove(): void };
         close(): void;
     }
 

--- a/houston-common-lib/lib/driver/cockpitDriver.ts
+++ b/houston-common-lib/lib/driver/cockpitDriver.ts
@@ -41,14 +41,15 @@ export function factory(): IHoustonDriver {
           if (this.spawnHandle === undefined) {
             return reject(new ProcessError(this.prefixMessage("Process never started!")));
           }
-          this.spawnHandle
+          const handle = this.spawnHandle;
+          handle
             .then((stdout, stderr) => {
-              this.spawnHandle = undefined;
+              if (this.spawnHandle === handle) this.spawnHandle = undefined;
               const exitStatus = 0;
               resolve(new ExitedProcess(this.server, this.command, exitStatus, stdout, stderr));
             })
             .catch((ex, stdout) => {
-              this.spawnHandle = undefined;
+              if (this.spawnHandle === handle) this.spawnHandle = undefined;
               if (
                 (ex.problem !== null && ex.problem !== undefined) ||
                 ex.exit_status === null ||

--- a/houston-common-lib/lib/driver/cockpitDriver.ts
+++ b/houston-common-lib/lib/driver/cockpitDriver.ts
@@ -43,10 +43,12 @@ export function factory(): IHoustonDriver {
           }
           this.spawnHandle
             .then((stdout, stderr) => {
+              this.spawnHandle = undefined;
               const exitStatus = 0;
               resolve(new ExitedProcess(this.server, this.command, exitStatus, stdout, stderr));
             })
             .catch((ex, stdout) => {
+              this.spawnHandle = undefined;
               if (
                 (ex.problem !== null && ex.problem !== undefined) ||
                 ex.exit_status === null ||

--- a/houston-common-lib/lib/legacy/useSpawn.ts
+++ b/houston-common-lib/lib/legacy/useSpawn.ts
@@ -159,7 +159,7 @@ const state = {
   state = {
     loading: true,
     argv: [...argv],
-    proc: cockpit.spawn(argv, opts as any),
+    proc: proc,
     stdout: undefined,
     stderr: undefined,
     status: undefined,
@@ -181,10 +181,6 @@ const state = {
     },
   };
 
-  
-  // Assign the proc and _promise to the state
-  state.proc = proc;
-  state._promise = _promise;
   // state = {
   //   loading: true,
   //   argv: [...argv],


### PR DESCRIPTION
useSpawn() double-spawn — Every call to useSpawn() executed cockpit.spawn() twice. 
The first spawn was wired to the promise chain. The second was embedded in the object literal initializing state, which immediately fired the command again on the server. Lines below then overwrote state.proc with the first spawn, orphaning the second. That orphaned process ran to completion with no tracking, no error handling, and no cleanup. Every useSpawn() call — used by getDatasets() in cockpit-zfs and BetterCockpitFile — silently ran each command twice and leaked the second process. Fixed by using the already-created proc reference directly in the object literal.

spawnHandle retained after exit — CockpitProcess stored the Cockpit spawn handle in this.spawnHandle but never cleared it after wait() resolved or rejected. Cockpit spawn handles hold references to the internal channel, stdout buffer, and stderr buffer. If anything retained the CockpitProcess object after completion (e.g. liveDriveSlots.ts stores ctx.proc), the handle and all its buffers couldn't be garbage collected. Fixed by setting this.spawnHandle = undefined in both the .then() and .catch() paths of wait().